### PR TITLE
重构状态机

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -66,7 +66,7 @@ export default class Client extends EventEmitter {
    * 重新连接
    */
   reconnect() {
-    return this._fsm.handle('connect');
+    return this._fsm.handle('reconnect');
   }
 
   /**
@@ -376,6 +376,7 @@ export default class Client extends EventEmitter {
 
   // 清理内存数据
   _clear() {
+    this.removeAllListeners();
     this._lobbyRoomList = null;
     this._masterServer = null;
     this._gameServer = null;

--- a/src/Client.js
+++ b/src/Client.js
@@ -80,19 +80,12 @@ export default class Client extends EventEmitter {
   }
 
   /**
-   * 断开连接
+   * 关闭
    */
-  disconnect() {
-    return this._fsm.handle('disconnect');
-  }
-
-  /**
-   * 重置
-   */
-  reset() {
-    debug('reset');
+  close() {
+    debug('close');
     this._clear();
-    return this._fsm.handle('reset');
+    return this._fsm.handle('close');
   }
 
   /**

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -195,9 +195,8 @@ export default class Connection extends EventEmitter {
     throw new Error('must implement the method');
   }
 
-  async _handleErrorMsg(msg) {
+  _handleErrorMsg(msg) {
     error(JSON.stringify(msg));
-    await this.close();
   }
 
   _handleErrorNotify(msg) {

--- a/src/LobbyConnection.js
+++ b/src/LobbyConnection.js
@@ -28,7 +28,6 @@ export default class LobbyConnection extends Connection {
         };
         const res = await super.send(msg);
         if (res.reasonCode) {
-          await this.close();
           const { reasonCode, detail } = res;
           reject(new PlayError(reasonCode, detail));
         } else {

--- a/src/PlayFSM.js
+++ b/src/PlayFSM.js
@@ -346,7 +346,12 @@ const PlayFSM = machina.Fsm.extend({
     },
 
     disconnect: {
-      reconnect() {},
+      reconnect() {
+        this.handle('onTransition', 'connecting');
+        return this._connectLobby().then(
+          tap(() => this.handle('onTransition', 'lobby'))
+        );
+      },
 
       reconnectAndRejoin() {
         this.handle('onTransition', 'connecting');
@@ -377,6 +382,10 @@ const PlayFSM = machina.Fsm.extend({
         } else if (nextState === 'game') {
           await this._gameConn.close();
         }
+      },
+
+      '*': evt => {
+        throw new Error(`Error event: ${evt.inputType} on close state`);
       },
     },
   },

--- a/src/PlayFSM.js
+++ b/src/PlayFSM.js
@@ -257,7 +257,7 @@ const PlayFSM = machina.Fsm.extend({
           await this._gameConn.close();
           await this._connectLobby().then(
             tap(() => {
-              this.handle('onTransition', 'lobby');
+              this.handle('onTransition', 'gameToLobby');
             })
           );
           this._play.emit(Event.ROOM_KICKED, { code, msg });
@@ -270,7 +270,7 @@ const PlayFSM = machina.Fsm.extend({
 
       onTransition(nextState) {
         if (
-          nextState === 'lobby' ||
+          nextState === 'gameToLobby' ||
           nextState === 'disconnect' ||
           nextState === 'close'
         ) {
@@ -281,6 +281,7 @@ const PlayFSM = machina.Fsm.extend({
       },
 
       leaveRoom() {
+        this.handle('onTransition', 'gameToLobby');
         return new Promise(async (resolve, reject) => {
           try {
             await this._gameConn.leaveRoom();
@@ -342,6 +343,20 @@ const PlayFSM = machina.Fsm.extend({
             reject(err);
           }
         });
+      },
+    },
+
+    gameToLobby: {
+      onTransition(nextState) {
+        if (nextState === 'lobby' || nextState === 'game') {
+          this.transition(nextState);
+        } else {
+          throw new Error(`Error transition: from gameToLobby to ${nextState}`);
+        }
+      },
+
+      close() {
+        this.transition('close');
       },
     },
 

--- a/src/PlayFSM.js
+++ b/src/PlayFSM.js
@@ -63,7 +63,11 @@ const PlayFSM = machina.Fsm.extend({
 
     connecting: {
       onTransition(nextState) {
-        if (nextState === 'lobby' || nextState === 'close') {
+        if (
+          nextState === 'lobby' ||
+          nextState === 'disconnect' ||
+          nextState === 'close'
+        ) {
           this.transition(nextState);
         } else {
           throw new Error(`Error transition: from connecting to ${nextState}`);
@@ -101,8 +105,8 @@ const PlayFSM = machina.Fsm.extend({
       onTransition(nextState) {
         if (
           nextState === 'lobbyToGame' ||
-          nextState === 'close' ||
-          nextState === 'disconnect'
+          nextState === 'disconnect' ||
+          nextState === 'close'
         ) {
           this.transition(nextState);
         } else {
@@ -153,7 +157,12 @@ const PlayFSM = machina.Fsm.extend({
 
     lobbyToGame: {
       onTransition(nextState) {
-        if (nextState === 'lobby' || nextState === 'game') {
+        if (
+          nextState === 'lobby' ||
+          nextState === 'game' ||
+          nextState === 'disconnect' ||
+          nextState === 'close'
+        ) {
           this.transition(nextState);
         } else {
           throw new Error(`Error transition: from lobbyToGame to ${nextState}`);
@@ -348,7 +357,12 @@ const PlayFSM = machina.Fsm.extend({
 
     gameToLobby: {
       onTransition(nextState) {
-        if (nextState === 'lobby' || nextState === 'game') {
+        if (
+          nextState === 'lobby' ||
+          nextState === 'game' ||
+          nextState === 'disconnect' ||
+          nextState === 'close'
+        ) {
           this.transition(nextState);
         } else {
           throw new Error(`Error transition: from gameToLobby to ${nextState}`);
@@ -363,6 +377,14 @@ const PlayFSM = machina.Fsm.extend({
     disconnect: {
       _onEnter() {
         this._play.emit(Event.DISCONNECTED);
+      },
+
+      onTransition(nextState) {
+        if (nextState === 'connecting' || nextState === 'close') {
+          this.transition(nextState);
+        } else {
+          throw new Error(`Error transition: from disconnect to ${nextState}`);
+        }
       },
 
       reconnect() {

--- a/src/PlayFSM.js
+++ b/src/PlayFSM.js
@@ -90,7 +90,7 @@ const PlayFSM = machina.Fsm.extend({
           this._play.emit(Event.LOBBY_ROOM_LIST_UPDATED);
         });
         this._lobbyConn.on(DISCONNECT_EVENT, () => {
-          this._play.emit(Event.DISCONNECTED);
+          this.handle('onTransition', 'disconnect');
         });
       },
 
@@ -251,7 +251,7 @@ const PlayFSM = machina.Fsm.extend({
           });
         });
         this._gameConn.on(DISCONNECT_EVENT, () => {
-          this._play.emit(Event.DISCONNECTED);
+          this.handle('onTransition', 'disconnect');
         });
         this._gameConn.on(ROOM_KICKED_EVENT, async (code, msg) => {
           await this._gameConn.close();
@@ -346,6 +346,10 @@ const PlayFSM = machina.Fsm.extend({
     },
 
     disconnect: {
+      _onEnter() {
+        this._play.emit(Event.DISCONNECTED);
+      },
+
       reconnect() {
         this.handle('onTransition', 'connecting');
         return this._connectLobby().then(

--- a/test/ChangeProperties.test.js
+++ b/test/ChangeProperties.test.js
@@ -24,8 +24,8 @@ describe('test change properties', () => {
         expect(props.gold).to.be.equal(1000);
         f0 = true;
         if (f0 && f1) {
-          await p0.disconnect();
-          await p1.disconnect();
+          await p0.close();
+          await p1.close();
           resolve();
         }
       });
@@ -37,8 +37,8 @@ describe('test change properties', () => {
         expect(props.gold).to.be.equal(1000);
         f1 = true;
         if (f0 && f1) {
-          await p0.disconnect();
-          await p1.disconnect();
+          await p0.close();
+          await p1.close();
           resolve();
         }
       });
@@ -66,8 +66,8 @@ describe('test change properties', () => {
         expect(props.gold).to.be.equal(1000);
         f0 = true;
         if (f0 && f1) {
-          await p0.disconnect();
-          await p1.disconnect();
+          await p0.close();
+          await p1.close();
           resolve();
         }
       });
@@ -81,8 +81,8 @@ describe('test change properties', () => {
         expect(props.gold).to.be.equal(1000);
         f1 = true;
         if (f0 && f1) {
-          await p0.disconnect();
-          await p1.disconnect();
+          await p0.close();
+          await p1.close();
           resolve();
         }
       });
@@ -131,8 +131,8 @@ describe('test change properties', () => {
         expect(arr[2].num).to.be.equal(13);
         f0 = true;
         if (f0 && f1) {
-          await p0.disconnect();
-          await p1.disconnect();
+          await p0.close();
+          await p1.close();
           resolve();
         }
       });
@@ -153,8 +153,8 @@ describe('test change properties', () => {
         expect(props.arr[2].num).to.be.equal(13);
         f1 = true;
         if (f0 && f1) {
-          p0.disconnect();
-          p1.disconnect();
+          p0.close();
+          p1.close();
           resolve();
         }
       });
@@ -191,8 +191,8 @@ describe('test change properties', () => {
         expect(props.gold).to.be.equal(1000);
         f0 = true;
         if (f0 && f1) {
-          await p0.disconnect();
-          await p1.disconnect();
+          await p0.close();
+          await p1.close();
           resolve();
         }
       });
@@ -207,8 +207,8 @@ describe('test change properties', () => {
         expect(props.gold).to.be.equal(1000);
         f1 = true;
         if (f0 && f1) {
-          await p0.disconnect();
-          await p1.disconnect();
+          await p0.close();
+          await p1.close();
           resolve();
         }
       });
@@ -252,7 +252,7 @@ describe('test change properties', () => {
     const me = p1.room.getPlayer(p1.player.actorId);
     debug(me);
     expect(master.getCustomProperties().ready).to.be.equal(true);
-    await p0.disconnect();
-    await p1.disconnect();
+    await p0.close();
+    await p1.close();
   });
 });

--- a/test/Connect.test.js
+++ b/test/Connect.test.js
@@ -39,10 +39,11 @@ describe('test connect', () => {
   });
 
   it('test disconnect from lobby', async () => {
-    const p = newPlay('tc2');
+    let p = newPlay('tc2');
     await p.connect();
     await p.close();
-    await p.reconnect();
+    p = newPlay('tc2');
+    await p.connect();
     await p.close();
   });
 

--- a/test/Connect.test.js
+++ b/test/Connect.test.js
@@ -13,7 +13,7 @@ describe('test connect', () => {
   it('test connect', async () => {
     const p = newPlay('tc0');
     await p.connect();
-    await p.disconnect();
+    await p.close();
   });
 
   it('test connect with same id', async () => {
@@ -27,30 +27,30 @@ describe('test connect', () => {
       if (code === 4102) {
         f0 = true;
         if (f0 && f1) {
-          p1.disconnect();
+          await p1.close();
         }
       }
     });
     await p1.connect();
     f1 = true;
     if (f0 && f1) {
-      p1.disconnect();
+      await p1.close();
     }
   });
 
   it('test disconnect from lobby', async () => {
     const p = newPlay('tc2');
     await p.connect();
-    await p.disconnect();
+    await p.close();
     await p.reconnect();
-    await p.disconnect();
+    await p.close();
   });
 
   it('test disconnect from game', async () => {
     const p = newPlay('tc3');
     await p.connect();
     await p.createRoom();
-    await p.disconnect();
+    await p.close();
   });
 
   it('test connect failed', async () => {
@@ -72,7 +72,7 @@ describe('test connect', () => {
     return new Promise(resolve => {
       setTimeout(() => {
         debug('keep alive timeout');
-        play.disconnect();
+        play.close();
         resolve();
       }, 30000);
     });
@@ -81,7 +81,7 @@ describe('test connect', () => {
   it('test wechat', async () => {
     const p = newWechatPlay('tc6');
     await p.connect();
-    await p.disconnect();
+    await p.close();
   });
 
   it('test ws', async () => {
@@ -101,7 +101,7 @@ describe('test connect', () => {
     const p = newPlay('tc_7');
     p.connect()
       .then(async () => {
-        await p.disconnect();
+        await p.close();
         done();
       })
       .catch(console.error);
@@ -130,7 +130,7 @@ describe('test connect', () => {
     return new Promise(resolve => {
       setTimeout(async () => {
         clearInterval(timer);
-        await p.disconnect();
+        await p.close();
         resolve();
       }, 30000);
     });

--- a/test/CreateRoom.test.js
+++ b/test/CreateRoom.test.js
@@ -9,7 +9,7 @@ describe('test create room', () => {
     const p = newPlay('cr1');
     await p.connect();
     await p.createRoom();
-    await p.disconnect();
+    await p.close();
   });
 
   it('test create simple room', async () => {
@@ -20,7 +20,7 @@ describe('test create room', () => {
       roomName,
     });
     expect(p.room.name).to.be.equal(roomName);
-    await p.disconnect();
+    await p.close();
   });
 
   it('test create custom room', async () => {
@@ -50,7 +50,7 @@ describe('test create room', () => {
     expect(props.title).to.be.equal('room title');
     expect(props.level).to.be.equal(2);
     expect(p.room.expectedUserIds).to.be.deep.equal(['world']);
-    await p.disconnect();
+    await p.close();
   });
 
   it('test create room failed', async () => {
@@ -65,8 +65,8 @@ describe('test create room', () => {
       await p1.createRoom({ roomName });
     } catch (err) {
       error(err);
-      await p0.disconnect();
-      await p1.disconnect();
+      await p0.close();
+      await p1.close();
     }
   });
 
@@ -90,8 +90,8 @@ describe('test create room', () => {
         expect(p0.room.playerList.length).to.be.equal(2);
         f0 = true;
         if (f0 && f1) {
-          await p0.disconnect();
-          await p1.disconnect();
+          await p0.close();
+          await p1.close();
           resolve();
         }
       });
@@ -100,8 +100,8 @@ describe('test create room', () => {
       expect(p1.room.playerList.length).to.be.equal(2);
       f1 = true;
       if (f0 && f1) {
-        await p0.disconnect();
-        await p1.disconnect();
+        await p0.close();
+        await p1.close();
         resolve();
       }
     });
@@ -119,7 +119,7 @@ describe('test create room', () => {
       p.on(Event.ROOM_VISIBLE_CHANGED, async data => {
         const { visible } = data;
         expect(visible).to.be.equal(false);
-        await p.disconnect();
+        await p.close();
         resolve();
       });
       p.setRoomOpened(false);

--- a/test/CustomEvent.test.js
+++ b/test/CustomEvent.test.js
@@ -18,8 +18,8 @@ describe('test custom event', () => {
         expect(eventId).to.be.equal('hi');
         expect(eventData.name).to.be.equal('aaaa');
         expect(eventData.body).to.be.equal('bbbb');
-        await p0.disconnect();
-        await p1.disconnect();
+        await p0.close();
+        await p1.close();
         resolve();
       });
 
@@ -52,8 +52,8 @@ describe('test custom event', () => {
         expect(eventData.body).to.be.equal('bbbb');
         f0 = true;
         if (f0 && f1) {
-          await p0.disconnect();
-          await p1.disconnect();
+          await p0.close();
+          await p1.close();
           resolve();
         }
       });
@@ -67,8 +67,8 @@ describe('test custom event', () => {
         expect(eventData.body).to.be.equal('bbbb');
         f1 = true;
         if (f0 && f1) {
-          await p0.disconnect();
-          await p1.disconnect();
+          await p0.close();
+          await p1.close();
           resolve();
         }
       });

--- a/test/JoinRoom.test.js
+++ b/test/JoinRoom.test.js
@@ -80,7 +80,7 @@ describe('test join room', () => {
   it('test rejoin room', async () => {
     const roomName = 'jr4_r';
     const p0 = newPlay('jr4_0');
-    const p1 = newPlay('jr4_1');
+    let p1 = newPlay('jr4_1');
 
     await p0.connect();
     const options = {
@@ -98,6 +98,8 @@ describe('test join room', () => {
     await p1.connect();
     await p1.joinRoom(roomName);
     await p1.close();
+
+    p1 = newPlay('jr4_1');
     await p1.connect();
     await p1.rejoinRoom(roomName);
 
@@ -108,7 +110,7 @@ describe('test join room', () => {
   it('test reconnectAndRejoin room', async () => {
     const roomName = 'jr5_r';
     const p0 = newPlay('jr5_0');
-    const p1 = newPlay('jr5_1');
+    let p1 = newPlay('jr5_1');
 
     await p0.connect();
     const options = {
@@ -122,6 +124,8 @@ describe('test join room', () => {
     await p1.connect();
     await p1.joinRoom(roomName);
     await p1.close();
+
+    p1 = newPlay('jr5_1');
     await p1.reconnectAndRejoin();
 
     await p0.close();

--- a/test/JoinRoom.test.js
+++ b/test/JoinRoom.test.js
@@ -14,8 +14,8 @@ describe('test join room', () => {
     });
     await p1.connect();
     await p1.joinRoom(roomName);
-    await p0.disconnect();
-    await p1.disconnect();
+    await p0.close();
+    await p1.close();
   });
 
   it('test join random room', async () => {
@@ -26,8 +26,8 @@ describe('test join room', () => {
     await p0.createRoom(roomName);
     await p1.connect();
     await p1.joinRandomRoom();
-    await p0.disconnect();
-    await p1.disconnect();
+    await p0.close();
+    await p1.close();
   });
 
   it('test join with expected userIds', async () => {
@@ -53,9 +53,9 @@ describe('test join room', () => {
       debug(err);
       await p2.connect();
       await p2.joinRoom(roomName);
-      await p0.disconnect();
-      await p1.disconnect();
-      await p2.disconnect();
+      await p0.close();
+      await p1.close();
+      await p2.close();
     }
   });
 
@@ -70,8 +70,8 @@ describe('test join room', () => {
       await p1.connect();
       await p1.joinRoom(roomName);
       p1.on(Event.PLAYER_ROOM_LEFT, async () => {
-        await p0.disconnect();
-        await p1.disconnect();
+        await p0.close();
+        await p1.close();
         resolve();
       });
       p0.leaveRoom();
@@ -97,12 +97,12 @@ describe('test join room', () => {
 
     await p1.connect();
     await p1.joinRoom(roomName);
-    await p1.disconnect();
+    await p1.close();
     await p1.connect();
     await p1.rejoinRoom(roomName);
 
-    await p0.disconnect();
-    await p1.disconnect();
+    await p0.close();
+    await p1.close();
   });
 
   it('test reconnectAndRejoin room', async () => {
@@ -121,11 +121,11 @@ describe('test join room', () => {
 
     await p1.connect();
     await p1.joinRoom(roomName);
-    await p1.disconnect();
+    await p1.close();
     await p1.reconnectAndRejoin();
 
-    await p0.disconnect();
-    await p1.disconnect();
+    await p0.close();
+    await p1.close();
   });
 
   it('test join name room failed', async () => {
@@ -142,8 +142,8 @@ describe('test join room', () => {
       await p1.joinRoom(roomName2);
     } catch (err) {
       debug(err);
-      await p0.disconnect();
-      await p1.disconnect();
+      await p0.close();
+      await p1.close();
     }
   });
 
@@ -184,9 +184,9 @@ describe('test join room', () => {
       });
     } catch (err) {
       debug(err);
-      await p0.disconnect();
-      await p1.disconnect();
-      await p2.disconnect();
+      await p0.close();
+      await p1.close();
+      await p2.close();
     }
   });
 
@@ -208,8 +208,8 @@ describe('test join room', () => {
     await p1.joinRoom(roomName);
     await p2.joinRoom(roomName);
 
-    await p0.disconnect();
-    await p1.disconnect();
-    await p2.disconnect();
+    await p0.close();
+    await p1.close();
+    await p2.close();
   });
 });

--- a/test/Kick.test.js
+++ b/test/Kick.test.js
@@ -23,8 +23,8 @@ describe('test kick', () => {
         debug(`kicked: ${code}, ${msg}`);
         f1 = true;
         if (f0 && f1) {
-          await p0.disconnect();
-          await p1.disconnect();
+          await p0.close();
+          await p1.close();
           resolve();
         }
       });
@@ -32,8 +32,8 @@ describe('test kick', () => {
       await p0.kickPlayer(p1.player.actorId);
       f0 = true;
       if (f0 && f1) {
-        await p0.disconnect();
-        await p1.disconnect();
+        await p0.close();
+        await p1.close();
         resolve();
       }
     }));
@@ -57,8 +57,8 @@ describe('test kick', () => {
         expect(code).to.be.equal(404);
         f1 = true;
         if (f0 && f1) {
-          await p0.disconnect();
-          await p1.disconnect();
+          await p0.close();
+          await p1.close();
           resolve();
         }
       });
@@ -69,8 +69,8 @@ describe('test kick', () => {
       });
       f0 = true;
       if (f0 && f1) {
-        await p0.disconnect();
-        await p1.disconnect();
+        await p0.close();
+        await p1.close();
         resolve();
       }
     }));

--- a/test/Lobby.test.js
+++ b/test/Lobby.test.js
@@ -6,7 +6,7 @@ describe('test lobby', () => {
     const p = newPlay('tl0');
     await p.connect();
     await p.joinLobby();
-    await p.disconnect();
+    await p.close();
   });
 
   it('test room list update', async () =>
@@ -25,10 +25,10 @@ describe('test lobby', () => {
       await p3.joinLobby();
       p3.on(Event.LOBBY_ROOM_LIST_UPDATED, async () => {
         if (p3.lobbyRoomList.length >= 3) {
-          await p0.disconnect();
-          await p1.disconnect();
-          await p2.disconnect();
-          await p3.disconnect();
+          await p0.close();
+          await p1.close();
+          await p2.close();
+          await p3.close();
           resolve();
         }
       });

--- a/test/Log.test.js
+++ b/test/Log.test.js
@@ -12,6 +12,6 @@ describe('test log', () => {
     });
     const p = newPlay('tl0');
     await p.connect();
-    await p.disconnect();
+    await p.close();
   });
 });

--- a/test/Master.test.js
+++ b/test/Master.test.js
@@ -33,7 +33,7 @@ describe('test master', () => {
         expect(p1.room.masterId).to.be.equal(newMaster.actorId);
         f1 = true;
         if (f0 && f1) {
-          await p1.close();
+          await p0.close();
           await p1.close();
           resolve();
         }

--- a/test/Master.test.js
+++ b/test/Master.test.js
@@ -21,8 +21,8 @@ describe('test master', () => {
         expect(p0.room.masterId).to.be.equal(newMaster.actorId);
         f0 = true;
         if (f0 && f1) {
-          await p0.disconnect();
-          await p1.disconnect();
+          await p0.close();
+          await p1.close();
           resolve();
         }
       });
@@ -33,8 +33,8 @@ describe('test master', () => {
         expect(p1.room.masterId).to.be.equal(newMaster.actorId);
         f1 = true;
         if (f0 && f1) {
-          await p1.disconnect();
-          await p1.disconnect();
+          await p1.close();
+          await p1.close();
           resolve();
         }
       });
@@ -54,8 +54,8 @@ describe('test master', () => {
       p1.on(Event.MASTER_SWITCHED, async data => {
         const { newMaster } = data;
         expect(p1.player.actorId).to.be.equal(newMaster.actorId);
-        await p0.disconnect();
-        await p1.disconnect();
+        await p0.close();
+        await p1.close();
         resolve();
       });
       await p0.leaveRoom();
@@ -86,8 +86,8 @@ describe('test master', () => {
         expect(newMaster).to.be.equal(null);
         expect(p1.room.masterId).to.be.equal(-1);
         expect(p1.room.master).to.be.equal(null);
-        await p0.disconnect();
-        await p1.disconnect();
+        await p0.close();
+        await p1.close();
         resolve();
       });
       await p0.leaveRoom();

--- a/test/Reset.test.js
+++ b/test/Reset.test.js
@@ -4,19 +4,21 @@ const debug = require('debug')('Test:close');
 
 describe('test close', () => {
   it('test close', async () => {
-    const p = newPlay('tr0_0');
+    let p = newPlay('tr0_0');
     await p.connect();
     await p.createRoom();
     await p.close();
+    p = newPlay('tr0_0');
     await p.connect();
     await p.createRoom();
     await p.close();
   });
 
   it('test router connecting close', async () => {
-    const p = newPlay('tr1_0');
+    let p = newPlay('tr1_0');
     p.connect();
     await p.close();
+    p = newPlay('tr1_0');
     await p.connect();
     await p.close();
   });
@@ -33,10 +35,11 @@ describe('test close', () => {
   });
 
   it('test game connecting close', async () => {
-    const p = newPlay('tr3_0');
+    let p = newPlay('tr3_0');
     await p.connect();
     p.createRoom();
     await p.close();
+    p = newPlay('tr3_0');
     await p.connect();
     await p.createRoom();
     await p.close();

--- a/test/Reset.test.js
+++ b/test/Reset.test.js
@@ -1,44 +1,44 @@
 import { newPlay } from './Utils';
 
-const debug = require('debug')('Test:Reset');
+const debug = require('debug')('Test:close');
 
-describe('test reset', () => {
-  it('test reset', async () => {
+describe('test close', () => {
+  it('test close', async () => {
     const p = newPlay('tr0_0');
     await p.connect();
     await p.createRoom();
-    await p.reset();
+    await p.close();
     await p.connect();
     await p.createRoom();
-    await p.disconnect();
+    await p.close();
   });
 
-  it('test router connecting reset', async () => {
+  it('test router connecting close', async () => {
     const p = newPlay('tr1_0');
     p.connect();
-    await p.reset();
+    await p.close();
     await p.connect();
-    await p.disconnect();
+    await p.close();
   });
 
-  it('test lobby connecting reset', async () => {
+  it('test lobby connecting close', async () => {
     const p = newPlay('tr2_0');
     p._fsm.on('transition', async data => {
       debug(`transition: from ${data.fromState} to ${data.toState}`);
-      if (data.toState === 'lobbyConnected') {
-        await p.reset();
+      if (data.toState === 'lobby') {
+        await p.close();
       }
     });
     await p.connect();
   });
 
-  it('test game connecting reset', async () => {
+  it('test game connecting close', async () => {
     const p = newPlay('tr3_0');
     await p.connect();
     p.createRoom();
-    await p.reset();
+    await p.close();
     await p.connect();
     await p.createRoom();
-    await p.disconnect();
+    await p.close();
   });
 });

--- a/test/Router.test.js
+++ b/test/Router.test.js
@@ -4,6 +4,6 @@ describe('test router', () => {
   it('test app router', async () => {
     const p = newPlay('tar0');
     await p.connect();
-    await p.disconnect();
+    await p.close();
   });
 });


### PR DESCRIPTION
- 目前状态机划分为 8 个状态，初始状态（init），连接状态（connecting），大厅状态（lobby），大厅连接房间状态（lobbyToGame），房间状态（game），房间返回大厅状态（gameToLobby），断线状态（disconnect），关闭状态（close）
  - 切换状态的实现没有直接调用 machina 的 transition('nextState')，而是通过 handle('onTransition', 'nextState')，将转移状态的请求交由「当前状态」后，再确定是否转移。 
- 去掉之前的 disconnect()，disconnect 和「断线事件」有歧义，且和之前的 reset() 重叠。
- reset() 更名为 close()，更符合含义。除了关闭状态外，都可以安全调用 close() 关闭当前客户端。如需再使用，需要重新 init()