### PR TITLE
chore: reduce package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,9 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist/",
+    "play.d.ts"
+  ]
 }


### PR DESCRIPTION
close #258 

以下是修改后的打包结果，请确认有无遗漏。
```
$ npm pack --dry-run
npm notice
npm notice 📦  @leancloud/play@1.0.0
npm notice === Tarball Contents ===
npm notice 1.1MB   dist/play-laya.js
npm notice 599.7kB dist/play-node.js
npm notice 1.1MB   dist/play-weapp.js
npm notice 1.1MB   dist/play.js
npm notice 789.9kB dist/play.min.js
npm notice 2.4kB   package.json
npm notice 1.9MB   dist/play-laya.js.map
npm notice 800.6kB dist/play-node.js.map
npm notice 2.0MB   dist/play-weapp.js.map
npm notice 1.9MB   dist/play.js.map
npm notice 1.9MB   dist/play.min.js.map
npm notice 1.6kB   README.md
npm notice 7.5kB   play.d.ts
npm notice === Tarball Details ===
npm notice name:          @leancloud/play
npm notice version:       1.0.0
npm notice filename:      leancloud-play-1.0.0.tgz
npm notice package size:  1.9 MB
npm notice unpacked size: 13.1 MB
npm notice shasum:        58b1de7912804a4b0f17b4becdb34e0ea5329555
npm notice integrity:     sha512-POEoGzBHkAq6z[...]eHJo9ld/zLzxQ==
npm notice total files:   13
npm notice
leancloud-play-1.0.0.tgz
```