### PR TITLE
feat(CodecUtils): ignore entry with a undefined value

### DIFF
--- a/src/CodecUtils.js
+++ b/src/CodecUtils.js
@@ -170,10 +170,13 @@ function serializeObject(obj) {
     return null;
   }
   const entryList = [];
-  Object.keys(obj).forEach(k => {
+  Object.entries(obj).forEach(([key, val]) => {
+    if (typeof val === 'undefined') {
+      return;
+    }
     const entry = new GenericCollection.MapEntry();
-    entry.setKey(k);
-    entry.setVal(serialize(obj[k]));
+    entry.setKey(key);
+    entry.setVal(serialize(val));
     entryList.push(entry);
   });
   const map = new GenericCollection();


### PR DESCRIPTION
序列化 Object 时忽略值为 `undefined` 的 entry。

这样使用起来更友好一点。